### PR TITLE
Added optional link to .rev file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Happy Defolding!
 ## Credits
 
 * Rive model by Agustin R.
+** Optional - Rive Editable `Defold_Splash.rev` file can be downloaded at https://github.com/FlexYourBrain/defold_splash-REV


### PR DESCRIPTION
- Added .rev file link to README.me

 In the template-rive project `defold_splash.riv` is used but there is no rev file provided that can be edited in the rive editor. This file can be useful to users that want to learn how it was setup in both defold and rive. I've added the .rev file to github and in this README.md I provide a link to the optional file for those interested.

Fixes - #3